### PR TITLE
Computes a quantitative measure that assesses accuracy of network inference by also accounting for indirect paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/.*
 *.ipynb_checkpoints*
 .DS_Store
 .idea/
+venv/*

--- a/BLEval/__init__.py
+++ b/BLEval/__init__.py
@@ -207,11 +207,20 @@ class BLEval(object):
         for each algorithm-dataset combination.
 
         :returns:
-            None
+            - AUPRC: A dataframe containing AUPRC values for each algorithm-dataset combination
+            - AUROC: A dataframe containing AUROC values for each algorithm-dataset combination
         '''
+        scoresDFs = []
         for algo in tqdm(self.input_settings.algorithms, unit = " Algorithms"):
             if algo[1]['should_run'] == True:
-                CLR(self, algo[0])
+                scoresDF = CLR(self, algo[0])
+                if len(scoresDF)>0:
+                    scoresDFs.append(scoresDF)
+
+        auprcDF = pd.pivot_table(pd.concat(scoresDFs), values='AUPRC', index='algorithm', columns='dataset')
+        aurocDF = pd.pivot_table(pd.concat(scoresDFs), values='AUROC', index='algorithm', columns='dataset')
+        return auprcDF, aurocDF
+
 
     def computeBorda(self, selectedAlgorithms=None, aggregationMethod="average"):
 

--- a/BLEval/__init__.py
+++ b/BLEval/__init__.py
@@ -105,7 +105,7 @@ class BLEval(object):
         self.output_settings = output_settings
 
 
-    def computeAUC(self, directed = True, userReferenceNetworkFile=None):
+    def computeAUC(self, directed = True, userReferenceNetworkFile=None, tfsFile=None, ignoreEdgesFromTFs=False):
 
         '''
         Computes areas under the precision-recall (PR) and
@@ -125,6 +125,18 @@ class BLEval(object):
             The file should be comma separated and have following node column
             names: `Gene1` and `Gene2`.
 
+        tfsFile: str
+            The path to a file that specifiy a list of transcription factors in
+            the reference network. Default is None.
+
+        ignoreEdgesFromTFs: bool
+            A flag to indicate whether to ignore edges from transcription
+            factors or not. If ignoreEdgesFromTFs=True, the function will try to
+            fetch list of transcription factors from the file specified by
+            `tfsFile` attribute and then edges from transcription factors in the
+            reference network will be ignored and considered a negative.
+            Default is False.
+
         :returns:
             - AUPRC: A dataframe containing AUPRC values for each algorithm-dataset combination
             - AUROC: A dataframe containing AUROC values for each algorithm-dataset combination
@@ -133,10 +145,12 @@ class BLEval(object):
         AUROCDict = {}
 
         print("Predictions and connections in reference network will be treated as %s edges." % ('directed' if directed else 'undirected'))
+
+        if ignoreEdgesFromTFs and tfsFile is not None:
+            print("Ignoring the edges from transcription factors specified in the file at path: %s.\n" % tfsFile)
+
         if userReferenceNetworkFile is not None:
             print("Using the file at path: %s as reference network.\n\n" % userReferenceNetworkFile)
-
-
 
         for dataset in tqdm(self.input_settings.datasets,
                             total = len(self.input_settings.datasets), unit = " Datasets"):
@@ -144,7 +158,9 @@ class BLEval(object):
             AUPRC, AUROC = PRROC(dataset, self.input_settings,
                             directed = directed,
                             userReferenceNetworkFile=userReferenceNetworkFile,
-                            selfEdges = False, plotFlag = False)
+                            selfEdges = False, plotFlag = False,
+                            tfsFile=tfsFile,
+                            ignoreEdgesFromTFs=ignoreEdgesFromTFs)
             AUPRCDict[dataset['name']] = AUPRC
             AUROCDict[dataset['name']] = AUROC
         AUPRC = pd.DataFrame(AUPRCDict)

--- a/BLEval/__init__.py
+++ b/BLEval/__init__.py
@@ -105,7 +105,7 @@ class BLEval(object):
         self.output_settings = output_settings
 
 
-    def computeAUC(self, directed = True, userReferenceNetworkFile=None, tfsFile=None, ignoreEdgesFromTFs=False):
+    def computeAUC(self, directed = True, userReferenceNetworkFile=None, tfsFile=None, onlyEdgesFromTFs=False):
 
         '''
         Computes areas under the precision-recall (PR) and
@@ -129,13 +129,13 @@ class BLEval(object):
             The path to a file that specifiy a list of transcription factors in
             the reference network. Default is None.
 
-        ignoreEdgesFromTFs: bool
-            A flag to indicate whether to ignore edges from transcription
-            factors or not. If ignoreEdgesFromTFs=True, the function will try to
+        onlyEdgesFromTFs: bool
+            A flag to indicate whether to ignore edges from non-transcription
+            factors or not. If onlyEdgesFromTFs=True, the function will try to
             fetch list of transcription factors from the file specified by
-            `tfsFile` attribute and then edges from transcription factors in the
-            reference network will be ignored and considered a negative.
-            Default is False.
+            `tfsFile` attribute and then edges from nodes other than transcription
+            factors in the reference network will be ignored and considered a
+            negative. Default is False.
 
         :returns:
             - AUPRC: A dataframe containing AUPRC values for each algorithm-dataset combination
@@ -146,8 +146,8 @@ class BLEval(object):
 
         print("Predictions and connections in reference network will be treated as %s edges." % ('directed' if directed else 'undirected'))
 
-        if ignoreEdgesFromTFs and tfsFile is not None:
-            print("Ignoring the edges from transcription factors specified in the file at path: %s.\n" % tfsFile)
+        if onlyEdgesFromTFs and tfsFile is not None:
+            print("Ignoring the edges from nodes other than transcription factors specified in the file at path: %s.\n" % tfsFile)
 
         if userReferenceNetworkFile is not None:
             print("Using the file at path: %s as reference network.\n\n" % userReferenceNetworkFile)
@@ -160,7 +160,7 @@ class BLEval(object):
                             userReferenceNetworkFile=userReferenceNetworkFile,
                             selfEdges = False, plotFlag = False,
                             tfsFile=tfsFile,
-                            ignoreEdgesFromTFs=ignoreEdgesFromTFs)
+                            onlyEdgesFromTFs=onlyEdgesFromTFs)
             AUPRCDict[dataset['name']] = AUPRC
             AUROCDict[dataset['name']] = AUROC
         AUPRC = pd.DataFrame(AUPRCDict)

--- a/BLEval/__init__.py
+++ b/BLEval/__init__.py
@@ -31,6 +31,7 @@ from networkx.convert_matrix import from_pandas_adjacency
 # local imports
 from BLEval.computeCLR import CLR
 from BLEval.computeAUC import PRROC
+from BLEval.computekAUC import kPRROC
 from BLEval.parseTime import getTime
 from BLEval.computeBorda import Borda
 from BLEval.computeJaccard import Jaccard
@@ -221,6 +222,26 @@ class BLEval(object):
         aurocDF = pd.pivot_table(pd.concat(scoresDFs), values='AUROC', index='algorithm', columns='dataset')
         return auprcDF, aurocDF
 
+    def computekAUC(self, k=1):
+        '''
+        Computes areas under the k-precision-recall (PR) and
+        and k-ROC plots for each algorithm-dataset combination.
+
+        Parameters
+        ----------
+        k: int
+            A predicted edge (a,b) is considered a TP if there is a
+            path of length less than equal to k between a and b.
+            So a 1-PR curve is just the regular PR curve.
+
+        :returns:
+            - AUPRC: A dataframe containing k-AUPRC values for each algorithm-dataset combination
+            - AUROC: A dataframe containing k-AUROC values for each algorithm-dataset combination
+        '''
+        kprrocDF = kPRROC(self, k=k)
+        auprcDF = pd.pivot_table(kprrocDF, values='AUPRC', index='algorithm', columns='dataset')
+        aurocDF = pd.pivot_table(kprrocDF, values='AUROC', index='algorithm', columns='dataset')
+        return auprcDF, aurocDF
 
     def computeBorda(self, selectedAlgorithms=None, aggregationMethod="average"):
 

--- a/BLEval/__init__.py
+++ b/BLEval/__init__.py
@@ -3,7 +3,7 @@
 BEELINE Evaluation (:mod:`BLEval`) module contains the following main class:
 
 - :class:`BLEval.BLEval`
-and three additional classes used in the definition 
+and three additional classes used in the definition
 of BLEval class
 
 - :class:`BLEval.ConfigParser`
@@ -44,7 +44,7 @@ class InputSettings(object):
     The class for storing the names of input files.
     This initilizes an InputSettings object based on the
     following three parameters.
-    
+
     Parameters
     -----------
     datadir: str
@@ -52,7 +52,7 @@ class InputSettings(object):
 
     datasets: list
         List of dataset names
-        
+
     algorithms: list
         List of algorithm names
     '''
@@ -66,11 +66,11 @@ class InputSettings(object):
 
 
 class OutputSettings(object):
-    '''    
+    '''
     The class for storing the names of directories that output should
     be written to. This initilizes an OutputSettings object based on the
     following two parameters.
-    
+
     Parameters
     ----------
     base_dir: str
@@ -78,7 +78,7 @@ class OutputSettings(object):
 
     output_prefix: str
         A prefix added to the final output files.
-    
+
     '''
 
     def __init__(self, base_dir, output_prefix: Path) -> None:
@@ -108,14 +108,14 @@ class BLEval(object):
         '''
         Computes areas under the precision-recall (PR) and
         and ROC plots for each algorithm-dataset combination.
-      
+
         Parameters
         ----------
         directedFlag: bool
             A flag to specifiy whether to treat predictions
-            as directed edges (directed = True) or 
+            as directed edges (directed = True) or
             undirected edges (directed = False).
-        
+
         :returns:
             - AUPRC: A dataframe containing AUPRC values for each algorithm-dataset combination
             - AUROC: A dataframe containing AUROC values for each algorithm-dataset combination
@@ -123,29 +123,29 @@ class BLEval(object):
         AUPRCDict = {}
         AUROCDict = {}
 
-        for dataset in tqdm(self.input_settings.datasets, 
+        for dataset in tqdm(self.input_settings.datasets,
                             total = len(self.input_settings.datasets), unit = " Datasets"):
-            
-            AUPRC, AUROC = PRROC(dataset, self.input_settings, 
+
+            AUPRC, AUROC = PRROC(dataset, self.input_settings,
                                     directed = directed, selfEdges = False, plotFlag = False)
             AUPRCDict[dataset['name']] = AUPRC
             AUROCDict[dataset['name']] = AUROC
         AUPRC = pd.DataFrame(AUPRCDict)
         AUROC = pd.DataFrame(AUROCDict)
         return AUPRC, AUROC
-    
+
 
     def parseTime(self):
         """
         Parse time output for each
         algorithm-dataset combination.
-        
+
         :returns:
             A dictionary of times for all dataset-algorithm combinations
         """
         TimeDict = dict()
 
-        for dataset in tqdm(self.input_settings.datasets, 
+        for dataset in tqdm(self.input_settings.datasets,
                             total = len(self.input_settings.datasets), unit = " Datasets"):
             timevals  = getTime(self, dataset)
             TimeDict[dataset["name"]] = timevals
@@ -157,7 +157,7 @@ class BLEval(object):
         '''
         Computes Jaccard Index between top-k edge predictions
         of the same algorithm.
-        
+
         :returns:
             A dataframe containing the median and median absolute
             deviation of the Jaccard Index values of each algorithm
@@ -171,17 +171,17 @@ class BLEval(object):
         for algo in tqdm(self.input_settings.algorithms, unit = " Algorithms"):
             if algo[1]['should_run'] == True:
                 JaccDF['Jaccard Median'][algo[0]], JaccDF['Jaccard MAD'][algo[0]] = Jaccard(self, algo[0])
-            
-        return pd.DataFrame(JaccDF)     
 
-    
+        return pd.DataFrame(JaccDF)
+
+
     def computeSpearman(self):
 
         '''
         Finds the Spearman's correlation coefficient between
         the ranked edges of the same algorithm on the given
         set of datasets.
-        
+
         :returns:
             A dataframe containing the median and median absolute
             deviation of the Separman's correlation values of each algorithm.
@@ -194,64 +194,75 @@ class BLEval(object):
         for algo in tqdm(self.input_settings.algorithms, unit = " Algorithms"):
             if algo[1]['should_run'] == True:
                 corrDF['Spearman Median'][algo[0]],corrDF['Spearman MAD'][algo[0]] = Spearman(self, algo[0])
-            
+
         return pd.DataFrame(corrDF)
-    
-    
+
+
     def computeCLR(self):
 
         '''
-        Computes the infered ranked list using the 
-        CLR (Context Likelihood or Relatedness Network) algorithm 
+        Computes the infered ranked list using the
+        CLR (Context Likelihood or Relatedness Network) algorithm
         for each algorithm-dataset combination.
-        
+
         :returns:
             None
         '''
-        Eprec = {}
-        outDir = str(self.input_settings.datadir).replace("inputs", "outputs") + "/"
         for algo in tqdm(self.input_settings.algorithms, unit = " Algorithms"):
             if algo[1]['should_run'] == True:
                 CLR(self, algo[0])
 
+    def computeBorda(self):
+
+        '''
+        Computes edge ranked list using the Borda method for each dataset.
+
+        :returns:
+            None
+        '''
+        print("Borda")
+        # outDir = str(self.input_settings.datadir).replace("inputs", "outputs") + "/"
+        # for algo in tqdm(self.input_settings.algorithms, unit = " Algorithms"):
+            # if algo[1]['should_run'] == True:
+                # CLR(self, algo[0])
 
     def computeNetMotifs(self):
 
         '''
-        For each algorithm-dataset combination, this function computes the network motifs such as 
-        Feedforward loops, Feedback loops and 
+        For each algorithm-dataset combination, this function computes the network motifs such as
+        Feedforward loops, Feedback loops and
         Mutual interactions in the predicted top-k network. It returns the ratio of network motif counts
         compared to their respective values in the reference network.
-      
+
         :returns:
             - FBL: A dataframe containing ratios of number of Feedback loops
-            
+
             - FFL: A dataframe containing ratios of number of Feedforward loops
-            
+
             - MI: A dataframe containing ratios of number of Mutual Interactions
         '''
         FFLDict = {}
         FBLDict = {}
         MIDict = {}
-        for dataset in tqdm(self.input_settings.datasets, 
+        for dataset in tqdm(self.input_settings.datasets,
                             total = len(self.input_settings.datasets), unit = " Datasets"):
             FBLDict[dataset["name"]], FFLDict[dataset["name"]], MIDict[dataset["name"]] = Motifs(dataset, self.input_settings)
-            
+
         FBL = pd.DataFrame(FBLDict)
         FFL = pd.DataFrame(FFLDict)
         MI = pd.DataFrame(MIDict)
-        
+
         return FBL, FFL, MI
-                 
+
     def computeEarlyPrec(self):
 
         '''
         For each algorithm-dataset combination,
-        this function computes the Early Precision values of the 
+        this function computes the Early Precision values of the
         network formed using the predicted top-k edges.
-        
-        :returns: 
-            A dataframe containing the early precision values 
+
+        :returns:
+            A dataframe containing the early precision values
             for each algorithm-dataset combination.
 
         '''
@@ -264,15 +275,15 @@ class BLEval(object):
         return pd.DataFrame(Eprec).T
 
 
-    
+
     def computeSignedEPrec(self):
 
         '''
         For each algorithm-dataset combination,
-        this function computes the Early Precision values separately 
+        this function computes the Early Precision values separately
         for the activation and inhibitory edges.
-        
-        :returns: 
+
+        :returns:
             - A dataframe containing early precision for activation edges
             - A dataframe containing early precision for inhibitory edges
         '''
@@ -287,25 +298,25 @@ class BLEval(object):
                 sEPRDict['EPrec Activation'][algo[0]] = sEPrecDF['+']
                 sEPRDict['EPrec Inhibition'][algo[0]] = sEPrecDF['-']
         return(pd.DataFrame(sEPRDict['EPrec Activation']).T, pd.DataFrame(sEPRDict['EPrec Inhibition']).T)
-    
+
 
 class ConfigParser(object):
     '''
-    The class define static methods for parsing and storing the contents 
-    of the config file that sets a that sets a large number of parameters 
+    The class define static methods for parsing and storing the contents
+    of the config file that sets a that sets a large number of parameters
     used in the BLEval.
     '''
     @staticmethod
     def parse(config_file_handle) -> BLEval:
         '''
         A method for parsing the input .yaml file.
-        
+
         Parameters
         ----------
         config_file_handle: str
             Name of the .yaml file to be parsed
-        
-        :returns: 
+
+        :returns:
             An object of class :class:`BLEval.BLEval`.
 
         '''
@@ -315,11 +326,11 @@ class ConfigParser(object):
                 config_map['input_settings']),
             ConfigParser.__parse_output_settings(
                 config_map['output_settings']))
-    
+
     @staticmethod
     def __parse_input_settings(input_settings_map) -> InputSettings:
         '''
-        A method for parsing and initializing 
+        A method for parsing and initializing
         InputSettings object.
         '''
         input_dir = input_settings_map['input_dir']
@@ -339,15 +350,15 @@ class ConfigParser(object):
         A method for parsing the list of algorithms
         that are being evaluated, along with
         any parameters being passed.
-        
+
         Note that these parameters may not be
-        used in the current evaluation, but can 
+        used in the current evaluation, but can
         be used at a later point.
         '''
-        
+
         # Initilalize the list of algorithms
         algorithms = []
-        
+
         # Parse contents of algorithms_list
         for algorithm in algorithms_list:
                 combos = [dict(zip(algorithm['params'], val))
@@ -356,14 +367,14 @@ class ConfigParser(object):
                             for param in algorithm['params']))]
                 for combo in combos:
                     algorithms.append([algorithm['name'],combo])
-            
+
 
         return algorithms
 
     @staticmethod
     def __parse_output_settings(output_settings_map) -> OutputSettings:
         '''
-        A method for parsing and initializing 
+        A method for parsing and initializing
         Output object.
         '''
         output_dir = Path(output_settings_map['output_dir'])

--- a/BLEval/__init__.py
+++ b/BLEval/__init__.py
@@ -29,9 +29,10 @@ from networkx.convert_matrix import from_pandas_adjacency
 
 
 # local imports
+from BLEval.computeCLR import CLR
 from BLEval.computeAUC import PRROC
 from BLEval.parseTime import getTime
-from BLEval.computeCLR import CLR
+from BLEval.computeBorda import Borda
 from BLEval.computeJaccard import Jaccard
 from BLEval.computeSpearman import Spearman
 from BLEval.computeNetMotifs import Motifs
@@ -212,19 +213,40 @@ class BLEval(object):
             if algo[1]['should_run'] == True:
                 CLR(self, algo[0])
 
-    def computeBorda(self):
+    def computeBorda(self, selectedAlgorithms=None, aggregationMethod="average"):
 
         '''
         Computes edge ranked list using the Borda method for each dataset.
 
+        Parameters
+        ----------
+        selectedAlgorithms: [str]
+          List of algorithm names used to run borda method on selected
+          algorithms. If nothing is provided, the function runs borda on
+          all available algorithms.
+
+        aggregationMethod: str
+          Method used to aggregate rank in borda method. Available options are
+          {‘average’, ‘min’, ‘max’, ‘first’}, default ‘average’
+
         :returns:
             None
         '''
-        print("Borda")
-        # outDir = str(self.input_settings.datadir).replace("inputs", "outputs") + "/"
-        # for algo in tqdm(self.input_settings.algorithms, unit = " Algorithms"):
-            # if algo[1]['should_run'] == True:
-                # CLR(self, algo[0])
+        feasibleAlgorithmOptions = [algorithmName for algorithmName, _ in self.input_settings.algorithms]
+        feasibleaggregationMethodOptions = ['average', 'min', 'max', 'first']
+
+        selectedAlgorithms = feasibleAlgorithmOptions if selectedAlgorithms is None else selectedAlgorithms
+
+        for a in selectedAlgorithms:
+            if a not in feasibleAlgorithmOptions:
+                print("\nERROR: No data available on algorithm %s. Please choose an algorithm from the following options: %s" % (a, feasibleAlgorithmOptions))
+                return
+
+        if aggregationMethod not in feasibleaggregationMethodOptions:
+                print("\nERROR: Please choose an aggregation method algorithm from following options: " % feasibleaggregationMethodOptions)
+                return
+
+        Borda(self, selectedAlgorithms, aggregationMethod)
 
     def computeNetMotifs(self):
 

--- a/BLEval/computeAUC.py
+++ b/BLEval/computeAUC.py
@@ -9,7 +9,9 @@ from sklearn.metrics import precision_recall_curve, roc_curve, auc
 from itertools import product, permutations, combinations, combinations_with_replacement
 from tqdm import tqdm
 
-def PRROC(dataDict, inputSettings, directed = True, selfEdges = False, plotFlag = False, userReferenceNetworkFile=None):
+def PRROC(dataDict, inputSettings, directed = True, selfEdges = False,
+            plotFlag = False, userReferenceNetworkFile=None,
+            tfsFile=None, ignoreEdgesFromTFs=False):
     '''
     Computes areas under the precision-recall and ROC curves
     for a given dataset for each algorithm.
@@ -36,6 +38,18 @@ def PRROC(dataDict, inputSettings, directed = True, selfEdges = False, plotFlag 
             The file should be comma separated and have following node column
             names: `Gene1` and `Gene2`.
 
+        tfsFile: str
+            The path to a file that specifiy a list of transcription factors in
+            the reference network. Default is None.
+
+        ignoreEdgesFromTFs: bool
+            A flag to indicate whether to ignore edges from transcription
+            factors or not. If ignoreEdgesFromTFs=True, the function will try to
+            fetch list of transcription factors from the file specified by
+            `tfsFile` attribute and then edges from transcription factors in the
+            reference network will be ignored and considered a negative.
+            Default is False.
+
     :returns:
             - AUPRC: A dictionary containing AUPRC values for each algorithm
             - AUROC: A dictionary containing AUROC values for each algorithm
@@ -49,6 +63,14 @@ def PRROC(dataDict, inputSettings, directed = True, selfEdges = False, plotFlag 
                                     header = 0, index_col = None)
     else:
         trueEdgesDF = pd.read_csv(str(userReferenceNetworkFile), sep = ',', header = 0, index_col = None)
+
+
+    if ignoreEdgesFromTFs:
+        if tfsFile is None:
+            print('ERROR: Please specify the path to a file containing a list of transcription factors in order to ignore edges from the transcription factors.')
+        else:
+            tfsDF = pd.read_csv(str(tfsFile), index_col = None, names=['Gene1'])
+            trueEdgesDF = pd.merge(trueEdgesDF, tfsDF, on='Gene1', how='inner')
 
     # Initialize data dictionaries
     precisionDict = {}

--- a/BLEval/computeAUC.py
+++ b/BLEval/computeAUC.py
@@ -70,6 +70,7 @@ def PRROC(dataDict, inputSettings, directed = True, selfEdges = False,
             print('ERROR: Please specify the path to a file containing a list of transcription factors in order to ignore edges from the transcription factors.')
         else:
             tfsDF = pd.read_csv(str(tfsFile), index_col = None, names=['Gene1'])
+            # Only include edges in the reference network that start with a TF specified in `tfsFile` file
             trueEdgesDF = pd.merge(trueEdgesDF, tfsDF, on='Gene1', how='inner')
 
     # Initialize data dictionaries

--- a/BLEval/computeAUC.py
+++ b/BLEval/computeAUC.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 
 def PRROC(dataDict, inputSettings, directed = True, selfEdges = False,
             plotFlag = False, userReferenceNetworkFile=None,
-            tfsFile=None, ignoreEdgesFromTFs=False):
+            tfsFile=None, onlyEdgesFromTFs=False):
     '''
     Computes areas under the precision-recall and ROC curves
     for a given dataset for each algorithm.
@@ -42,13 +42,13 @@ def PRROC(dataDict, inputSettings, directed = True, selfEdges = False,
             The path to a file that specifiy a list of transcription factors in
             the reference network. Default is None.
 
-        ignoreEdgesFromTFs: bool
-            A flag to indicate whether to ignore edges from transcription
-            factors or not. If ignoreEdgesFromTFs=True, the function will try to
+        onlyEdgesFromTFs: bool
+            A flag to indicate whether to ignore edges from non-transcription
+            factors or not. If onlyEdgesFromTFs=True, the function will try to
             fetch list of transcription factors from the file specified by
-            `tfsFile` attribute and then edges from transcription factors in the
-            reference network will be ignored and considered a negative.
-            Default is False.
+            `tfsFile` attribute and then edges from nodes other than transcription
+            factors in the reference network will be ignored and considered a
+            negative. Default is False.
 
     :returns:
             - AUPRC: A dictionary containing AUPRC values for each algorithm
@@ -65,7 +65,7 @@ def PRROC(dataDict, inputSettings, directed = True, selfEdges = False,
         trueEdgesDF = pd.read_csv(str(userReferenceNetworkFile), sep = ',', header = 0, index_col = None)
 
 
-    if ignoreEdgesFromTFs:
+    if onlyEdgesFromTFs:
         if tfsFile is None:
             print('ERROR: Please specify the path to a file containing a list of transcription factors in order to ignore edges from the transcription factors.')
         else:

--- a/BLEval/computeBorda.py
+++ b/BLEval/computeBorda.py
@@ -9,6 +9,8 @@ import concurrent.futures
 import matplotlib.pyplot as plt
 from itertools import permutations
 from sklearn import preprocessing
+from rpy2.robjects import FloatVector
+from rpy2.robjects.packages import importr
 from sklearn.metrics import precision_recall_curve, roc_curve, auc
 sns.set(rc={"lines.linewidth": 2}, palette  = "deep", style = "ticks")
 
@@ -85,7 +87,12 @@ def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
 
             prec, recall, thresholds = precision_recall_curve(y_true=y_true, probas_pred=y_scores, pos_label=1)
             fpr, tpr, thresholds = roc_curve(y_true=y_true, y_score=y_scores, pos_label=1)
-            evaluation_scores.append([dataset["name"], algo, auc(recall, prec), auc(fpr, tpr)])
+
+            prroc = importr('PRROC')
+            prCurve = prroc.pr_curve(scores_class0 = FloatVector(list(y_scores)),
+                      weights_class0 = FloatVector(list(y_true)))
+
+            evaluation_scores.append([dataset["name"], algo, prCurve[2][0], auc(fpr, tpr)])
 
         evaluationDFs.append(pd.DataFrame(evaluation_scores, columns=["dataset", "algorithm", "AUPRC", "AUROC"]))
 

--- a/BLEval/computeBorda.py
+++ b/BLEval/computeBorda.py
@@ -74,7 +74,7 @@ def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
         rank_df['mBORDA'] = __normalize__(rank_df.rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
         rank_df['sBORDA'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
         rank_df['smBORDA'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
-        rank_df.to_csv("%s/%s-Borda.csv" % (outDir, dataset["name"]), index=False)
+        rank_df.to_csv("%s/%s-Borda.csv" % (outDir, dataset["name"]), index=True)
 
         refNetwork = refNetwork[["edge", "isReferenceEdge"]].set_index("edge")
         rank_df = pd.merge(rank_df, refNetwork, how='left', on='edge').fillna(0)
@@ -101,10 +101,10 @@ def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
              str(evalObject.input_settings.datadir).split("inputs")[1]
 
     auprcDF = pd.pivot_table(evaluationDFs, values='AUPRC', index='algorithm', columns='dataset')
-    auprcDF.to_csv("%s/%s-AUPRC-with-Borda.csv" % (outDir, dataset["name"].split("_")[0]), index=False)
+    auprcDF.to_csv("%s/%s-AUPRC-with-Borda.csv" % (outDir, dataset["name"].split("_")[0]), index=True)
 
     aurocDF = pd.pivot_table(evaluationDFs, values='AUROC', index='algorithm', columns='dataset')
-    aurocDF.to_csv("%s/%s-AUROC-with-Borda.csv" % (outDir, dataset["name"].split("_")[0]), index=False)
+    aurocDF.to_csv("%s/%s-AUROC-with-Borda.csv" % (outDir, dataset["name"].split("_")[0]), index=True)
 
     plt.figure(figsize=(18,6))
     sns.set_style("whitegrid")

--- a/BLEval/computeBorda.py
+++ b/BLEval/computeBorda.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import concurrent.futures
 from itertools import permutations
 from sklearn import preprocessing
+from sklearn.metrics import precision_recall_curve, roc_curve, auc
+
 
 
 def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
@@ -32,8 +34,9 @@ def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
     :returns:
         - None
     """
-    edges = []
+    evaluationDFs = []
     for dataset in tqdm(evalObject.input_settings.datasets):
+        edges = []
         for algorithmName, _ in tqdm(evalObject.input_settings.algorithms):
             outDir = str(evalObject.output_settings.base_dir) + \
                      str(evalObject.input_settings.datadir).split("inputs")[1] + \
@@ -47,6 +50,9 @@ def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
             try:
                 df = pd.read_csv(rank_path, sep="\t", header=0, index_col=None)
                 refNetwork = pd.read_csv(refNetwork_path, header=0, index_col=None)
+                refNetwork['edge'] = refNetwork.apply(lambda x: '%s-%s' % (x.Gene1, x.Gene2), axis=1)
+                refNetwork = refNetwork[refNetwork.Gene1!=refNetwork.Gene2]
+                refNetwork['isReferenceEdge'] = 1
                 all_edges_df = pd.DataFrame(list(permutations(np.unique(refNetwork.loc[:,['Gene1','Gene2']]), r = 2)), columns=['Gene1','Gene2'])
                 ranked_edges = pd.merge(all_edges_df, df, on=['Gene1','Gene2'], how='left')
                 ranked_edges.EdgeWeight = ranked_edges.EdgeWeight.fillna(0)
@@ -60,11 +66,36 @@ def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
                 print("\nSkipping Borda computation for ", algorithmName, "on path", outDir)
                 continue
         rank_df = pd.pivot_table(pd.concat(edges), values='normEdgeWeight', index='edge', columns='algo')
-        rank_df['Borda-AvgRank'] = __normalize__(rank_df.rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
-        rank_df['mBorda-AvgRank'] = __normalize__(rank_df.rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
-        rank_df['sBorda-AvgRank'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
-        rank_df['smBorda-AvgRank'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
+        rank_df['Borda'] = __normalize__(rank_df.rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
+        rank_df['mBorda'] = __normalize__(rank_df.rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
+        rank_df['sBorda'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
+        rank_df['smBorda'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
         rank_df.to_csv("%s/%s-Borda.csv" % (outDir, dataset["name"]), index=False)
+
+        refNetwork = refNetwork[["edge", "isReferenceEdge"]].set_index("edge")
+        rank_df = pd.merge(rank_df, refNetwork, how='left', on='edge').fillna(0)
+        rank_df.isReferenceEdge = rank_df.isReferenceEdge.astype(int)
+
+        evaluation_scores = []
+        for algo in rank_df.drop(['isReferenceEdge'], 1).columns:
+            y_true = rank_df['isReferenceEdge'].values
+            y_scores = rank_df[algo].values
+
+            prec, recall, thresholds = precision_recall_curve(y_true=y_true, probas_pred=y_scores, pos_label=1)
+            fpr, tpr, thresholds = roc_curve(y_true=y_true, y_score=y_scores, pos_label=1)
+            evaluation_scores.append([dataset["name"], algo, auc(recall, prec), auc(fpr, tpr)])
+
+        evaluationDFs.append(pd.DataFrame(evaluation_scores, columns=["dataset", "algorithm", "AUPRC", "AUROC"]))
+
+    outDir = str(evalObject.output_settings.base_dir) + \
+             str(evalObject.input_settings.datadir).split("inputs")[1]
+
+    auprcDF = pd.pivot_table(pd.concat(evaluationDFs), values='AUPRC', index='algorithm', columns='dataset')
+    auprcDF.to_csv("%s/%s-AUPRC-with-Borda.csv" % (outDir, dataset["name"].split("_")[0]), index=False)
+
+    aurocDF = pd.pivot_table(pd.concat(evaluationDFs), values='AUROC', index='algorithm', columns='dataset')
+    aurocDF.to_csv("%s/%s-AUROC-with-Borda.csv" % (outDir, dataset["name"].split("_")[0]), index=False)
+
 
 def __normalize__(arr):
     return 1.0*(arr-np.min(arr))/(np.max(arr)-np.min(arr))

--- a/BLEval/computeBorda.py
+++ b/BLEval/computeBorda.py
@@ -1,0 +1,70 @@
+import os
+import math
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+from pathlib import Path
+import concurrent.futures
+from itertools import permutations
+from sklearn import preprocessing
+
+
+def Borda(evalObject, selectedAlgorithms=None, aggregationMethod="average"):
+    """
+    A function to compute edge ranked list using the Borda method from
+    the predicted ranked edges, i.e., the outputs of different datasets
+    generated from the same reference network, for each dataset.
+
+    Parameters
+    ----------
+    evalObject: BLEval
+      An object of class :class:`BLEval.BLEval`.
+
+    selectedAlgorithms: [str]
+      List of algorithm names used to run borda method on selected
+      algorithms. If nothing is provided, the function runs borda on
+      all available algorithms.
+
+    aggregationMethod: str
+      Method used to aggregate rank in borda method. Available options are
+      {‘average’, ‘min’, ‘max’, ‘first’}, default ‘average’
+
+    :returns:
+        - None
+    """
+    edges = []
+    for dataset in tqdm(evalObject.input_settings.datasets):
+        for algorithmName, _ in tqdm(evalObject.input_settings.algorithms):
+            outDir = str(evalObject.output_settings.base_dir) + \
+                     str(evalObject.input_settings.datadir).split("inputs")[1] + \
+                     "/" + dataset["name"]
+            inDir = str(evalObject.input_settings.datadir) + "/" + dataset["name"]
+            rank_path = outDir + "/" + algorithmName + "/rankedEdges.csv"
+            refNetwork_path = inDir + "/" + dataset["trueEdges"]
+
+            if not os.path.isdir(outDir) or not os.path.isdir(inDir):
+                continue
+            try:
+                df = pd.read_csv(rank_path, sep="\t", header=0, index_col=None)
+                refNetwork = pd.read_csv(refNetwork_path, header=0, index_col=None)
+                all_edges_df = pd.DataFrame(list(permutations(np.unique(refNetwork.loc[:,['Gene1','Gene2']]), r = 2)), columns=['Gene1','Gene2'])
+                ranked_edges = pd.merge(all_edges_df, df, on=['Gene1','Gene2'], how='left')
+                ranked_edges.EdgeWeight = ranked_edges.EdgeWeight.fillna(0)
+                ranked_edges['absEdgeWeight'] = ranked_edges['EdgeWeight'].abs()
+                ranked_edges['normEdgeWeight'] = pd.DataFrame(preprocessing.MinMaxScaler().fit_transform(ranked_edges[['absEdgeWeight']]))[0]
+                ranked_edges['dataset'] = dataset["name"]
+                ranked_edges['algo'] = algorithmName
+                ranked_edges['edge'] = ranked_edges.apply(lambda x: '%s-%s' % (x.Gene1, x.Gene2), axis=1)
+                edges.append(ranked_edges)
+            except Exception as e:
+                print("\nSkipping Borda computation for ", algorithmName, "on path", outDir)
+                continue
+        rank_df = pd.pivot_table(pd.concat(edges), values='normEdgeWeight', index='edge', columns='algo')
+        rank_df['Borda-AvgRank'] = __normalize__(rank_df.rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
+        rank_df['mBorda-AvgRank'] = __normalize__(rank_df.rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
+        rank_df['sBorda-AvgRank'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=True, method=aggregationMethod).mean(axis=1).values)
+        rank_df['smBorda-AvgRank'] = __normalize__(rank_df[selectedAlgorithms].rank(ascending=False, method=aggregationMethod).apply(lambda x: 1.0/(x*x)).mean(axis=1).values)
+        rank_df.to_csv("%s/%s-Borda.csv" % (outDir, dataset["name"]), index=False)
+
+def __normalize__(arr):
+    return 1.0*(arr-np.min(arr))/(np.max(arr)-np.min(arr))

--- a/BLEval/computekAUC.py
+++ b/BLEval/computekAUC.py
@@ -80,7 +80,7 @@ def kPRROC(evalObject, k = 1, directed = True, userReferenceNetworkFile = None):
     return pd.DataFrame(evaluation_scores, columns=["dataset", "algorithm", "AUPRC", "AUROC"])
 
 
-def computeScores(refNetwork, predEdgeDF, k=1):
+def computeScores(refNetwork, predEdgeDF, k=1, directed=True):
     '''
     Computes k-precision-recall and k-ROC curves
     using scikit-learn for a given set of predictions in the

--- a/BLEval/computekAUC.py
+++ b/BLEval/computekAUC.py
@@ -1,0 +1,110 @@
+import os
+import math
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import networkx as nx
+from tqdm import tqdm
+from pathlib import Path
+import concurrent.futures
+import matplotlib.pyplot as plt
+from itertools import permutations
+from sklearn import preprocessing
+from sklearn.metrics import precision_recall_curve, roc_curve, auc
+sns.set(rc={"lines.linewidth": 2}, palette  = "deep", style = "ticks")
+
+
+def kPRROC(evalObject, k=1):
+    '''
+    Computes areas under the k-precision-recall (PR) and
+    and k-ROC plots for each algorithm-dataset combination.
+
+    Parameters
+    ----------
+    k: int
+        A predicted edge (a,b) is considered a TP if there is a
+        path of length less than equal to k between a and b.
+        So a 1-PR curve is just the regular PR curve.
+
+    :returns:
+        - kprrocDF: A dataframe containing k-AUPRC and k-AUROC values for each algorithm-dataset combination
+    '''
+
+    evaluation_scores = []
+    for dataset in tqdm(evalObject.input_settings.datasets):
+        edges = []
+        for algorithmName, _ in tqdm(evalObject.input_settings.algorithms):
+            outDir = str(evalObject.output_settings.base_dir) + \
+                     str(evalObject.input_settings.datadir).split("inputs")[1] + \
+                     "/" + dataset["name"]
+            inDir = str(evalObject.input_settings.datadir) + "/" + dataset["name"]
+            rank_path = outDir + "/" + algorithmName + "/rankedEdges.csv"
+            refNetwork_path = inDir + "/" + dataset["trueEdges"]
+
+            if not os.path.isdir(outDir) or not os.path.isdir(inDir):
+                continue
+            try:
+                refNetwork = pd.read_csv(refNetwork_path, header=0, index_col=None)
+                refNetwork = refNetwork[refNetwork.Gene1!=refNetwork.Gene2]
+
+                all_edges_df = pd.DataFrame(list(permutations(np.unique(refNetwork.loc[:,['Gene1','Gene2']]), r = 2)), columns=['Gene1','Gene2'])
+
+                df = pd.read_csv(rank_path, sep="\t", header=0, index_col=None)
+                predEdges = pd.merge(all_edges_df, df, on=['Gene1','Gene2'], how='left')
+                predEdges.EdgeWeight = predEdges.EdgeWeight.fillna(0)
+                predEdges['EdgeWeight'] = predEdges['EdgeWeight'].abs()
+
+                prec, recall, fpr, tpr, auprc, auroc = computeScores(refNetwork, predEdges, k=k)
+
+                evaluation_scores.append([dataset["name"], algorithmName, auprc, auroc])
+            except Exception as e:
+                print(e)
+                print("\nSkipping kAUC computation for %s algorithm and %s dataset on path %s" % (algorithmName, dataset["name"], outDir))
+                continue
+            
+    return pd.DataFrame(evaluation_scores, columns=["dataset", "algorithm", "AUPRC", "AUROC"])
+
+
+def computeScores(refNetwork, predEdgeDF, k=1):
+    '''
+    Computes k-precision-recall and k-ROC curves
+    using scikit-learn for a given set of predictions in the
+    form of a DataFrame.
+
+    Parameters
+    ----------
+    refNetworkDF: DataFrame
+        A pandas dataframe containing edges in the reference network.
+
+    predEdgeDF: DataFrame
+        A pandas dataframe containing the edge ranks from the prediced
+        network. The indices of this dataframe are all possible edges.
+        This dataframe only has one column to indicate the edge weights
+        in the predicted network. Higher the weight, higher the
+        edge confidence.
+
+    k: int
+        A predicted edge (a,b) is considered a TP if there is a
+        path of length less than equal to k between a and b.
+        So a 1-PR curve is just the regular PR curve.
+
+    :returns:
+        - prec: A list of precision values (for PR plot)
+        - recall: A list of precision values (for PR plot)
+        - fpr: A list of false positive rates (for ROC plot)
+        - tpr: A list of true positive rates (for ROC plot)
+        - AUPRC: Area under the precision-recall curve
+        - AUROC: Area under the ROC curve
+    '''
+    G = nx.from_pandas_edgelist(refNetwork, 'Gene1', 'Gene2', True, create_using=nx.DiGraph)
+    length = dict(nx.all_pairs_shortest_path_length(G, cutoff=k))
+    predEdgeDF['isTP'] = predEdgeDF.apply(lambda x: 1 if (x.Gene1 in length and x.Gene2 in length[x.Gene1]) else 0, axis=1)
+    predEdgeDF.isTP = predEdgeDF.isTP.astype(int)
+
+    y_true = predEdgeDF['isTP'].values
+    y_scores = predEdgeDF['EdgeWeight'].values
+
+    prec, recall, thresholds = precision_recall_curve(y_true=y_true, probas_pred=y_scores, pos_label=1)
+    fpr, tpr, thresholds = roc_curve(y_true=y_true, y_score=y_scores, pos_label=1)
+
+    return prec, recall, fpr, tpr, auc(recall, prec), auc(fpr, tpr)

--- a/BLEval/computekAUC.py
+++ b/BLEval/computekAUC.py
@@ -10,6 +10,8 @@ import concurrent.futures
 import matplotlib.pyplot as plt
 from itertools import permutations
 from sklearn import preprocessing
+from rpy2.robjects import FloatVector
+from rpy2.robjects.packages import importr
 from sklearn.metrics import precision_recall_curve, roc_curve, auc
 sns.set(rc={"lines.linewidth": 2}, palette  = "deep", style = "ticks")
 
@@ -128,7 +130,11 @@ def computeScores(refNetwork, predEdgeDF, k=1, directed=True):
     y_true = predEdgeDF['isTP'].values
     y_scores = predEdgeDF['EdgeWeight'].values
 
+    prroc = importr('PRROC')
+    prCurve = prroc.pr_curve(scores_class0 = FloatVector(list(y_scores)),
+              weights_class0 = FloatVector(list(y_true)))
+
     prec, recall, thresholds = precision_recall_curve(y_true=y_true, probas_pred=y_scores, pos_label=1)
     fpr, tpr, thresholds = roc_curve(y_true=y_true, y_score=y_scores, pos_label=1)
 
-    return prec, recall, fpr, tpr, auc(recall, prec), auc(fpr, tpr)
+    return prec, recall, fpr, tpr, prCurve[2][0], auc(fpr, tpr)

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -179,7 +179,7 @@ def main():
     # Computing areas under k-Precision-Recall and k-ROC curves while accounting for indirect paths of length k as TPs
     if (opts.indirect_auc):
         print('\n\nComputing areas under %s-Precision-Recall and %s-ROC curves' % (opts.indirect_auc_k, opts.indirect_auc_k))
-        AUPRC, AUROC = evalSummarizer.computekAUC(k=int(opts.indirect_auc_k), directed=not opts.undirected, userReferenceNetworkFile=str(opts.ref))
+        AUPRC, AUROC = evalSummarizer.computekAUC(k=int(opts.indirect_auc_k), directed=not opts.undirected, userReferenceNetworkFile=opts.ref)
         AUPRC.to_csv(outDir + '%s-AUPRC.csv' % opts.indirect_auc_k)
         AUROC.to_csv(outDir + '%s-AUROC.csv' % opts.indirect_auc_k)
 

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -71,6 +71,12 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('--borda-algo', action="append",
       help="Algorithms used to compute rank in borda method. Default option runs Borda on all algorithm.")
 
+    parser.add_argument('-i', '--indirect-auc', action="store_true", default=False,
+        help="Compute areas under k-Precision-Recall and k-ROC curves while accounting for indirect paths of length k as true edges.\n")
+
+    parser.add_argument('-k', '--indirect-auc-k', action="store", default=1,
+        help="A predicted edge (a,b) is considered a TP if there is a path of length less than equal to k between a and b. So a 1-PR curve is just the regular PR curve.\n")
+
     return parser
 
 def parse_arguments():
@@ -163,6 +169,13 @@ def main():
     if (opts.borda):
         print('\n\nComputing edge ranked list using the borda method')
         evalSummarizer.computeBorda(selectedAlgorithms=opts.borda_algo, aggregationMethod=opts.borda_agg)
+
+    # Computing areas under k-Precision-Recall and k-ROC curves while accounting for indirect paths of length k as TPs
+    if (opts.indirect_auc):
+        print('\n\nComputing areas under %s-Precision-Recall and %s-ROC curves' % (opts.indirect_auc_k, opts.indirect_auc_k))
+        AUPRC, AUROC = evalSummarizer.computekAUC(k=int(opts.indirect_auc_k))
+        AUPRC.to_csv(outDir + '%s-AUPRC.csv' % opts.indirect_auc_k)
+        AUROC.to_csv(outDir + '%s-AUROC.csv' % opts.indirect_auc_k)
 
 
     print('\n\nEvaluation complete...\n')

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -77,6 +77,12 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-k', '--indirect-auc-k', action="store", default=1,
         help="A predicted edge (a,b) is considered a TP if there is a path of length less than equal to k between a and b. So a 1-PR curve is just the regular PR curve.\n")
 
+    parser.add_argument('-R','--ref', default=None,
+        help="Reference network file containing list of true positive (TP) edges. This option can be used in conjuction with `--auc` or `--indirect-auc` option to compute AUPRC and AUROC scores with given network as reference. The file should be comma separated and have following node column names: `Gene1` and `Gene2`.\n")
+
+    parser.add_argument('-u','--undirected', action="store_true", default=False,
+      help="A flag to indicate whether to treat predictions as undirected edges (undirected = True) or directed edges (undirected = False) during AUC computations. This option can be used in conjuction with `--auc` or `--indirect-auc`. ")
+
     return parser
 
 def parse_arguments():
@@ -109,7 +115,7 @@ def main():
     if (opts.auc):
         print('\n\nComputing areas under ROC and PR curves...')
 
-        AUPRC, AUROC = evalSummarizer.computeAUC()
+        AUPRC, AUROC = evalSummarizer.computeAUC(userReferenceNetworkFile=opts.ref, directed=not opts.undirected)
         AUPRC.to_csv(outDir+'AUPRC.csv')
         AUROC.to_csv(outDir+'AUROC.csv')
 
@@ -173,7 +179,7 @@ def main():
     # Computing areas under k-Precision-Recall and k-ROC curves while accounting for indirect paths of length k as TPs
     if (opts.indirect_auc):
         print('\n\nComputing areas under %s-Precision-Recall and %s-ROC curves' % (opts.indirect_auc_k, opts.indirect_auc_k))
-        AUPRC, AUROC = evalSummarizer.computekAUC(k=int(opts.indirect_auc_k))
+        AUPRC, AUROC = evalSummarizer.computekAUC(k=int(opts.indirect_auc_k), directed=not opts.undirected, userReferenceNetworkFile=str(opts.ref))
         AUPRC.to_csv(outDir + '%s-AUPRC.csv' % opts.indirect_auc_k)
         AUROC.to_csv(outDir + '%s-AUROC.csv' % opts.indirect_auc_k)
 

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -81,7 +81,15 @@ def get_parser() -> argparse.ArgumentParser:
         help="Reference network file containing list of true positive (TP) edges. This option can be used in conjuction with `--auc` or `--indirect-auc` option to compute AUPRC and AUROC scores with given network as reference. The file should be comma separated and have following node column names: `Gene1` and `Gene2`.\n")
 
     parser.add_argument('-u','--undirected', action="store_true", default=False,
-      help="A flag to indicate whether to treat predictions as undirected edges (undirected = True) or directed edges (undirected = False) during AUC computations. This option can be used in conjuction with `--auc` or `--indirect-auc`. ")
+      help="A flag to indicate whether to treat predictions as undirected edges (undirected = True) or directed edges (undirected = False) during AUC computations. This option can be used in conjuction with `--auc` or `--indirect-auc`.\n")
+
+
+    parser.add_argument('--tfs', action="store", default=None,
+      help="Path to a file containing list of transcription factors.\n")
+
+    parser.add_argument('--ignore-edges-from-tfs', action="store_true", default=False,
+      help="A flag to indicate whether to ignore edges from transcription factors or not. If ignore_edges_from_tfs=True, edges from transcription factors in the reference network will be ignored and considered a negative. This option requires the user to provide a list of transcription factors using the `--tfs` option.\n")
+
 
     return parser
 
@@ -115,7 +123,11 @@ def main():
     if (opts.auc):
         print('\n\nComputing areas under ROC and PR curves...')
 
-        AUPRC, AUROC = evalSummarizer.computeAUC(userReferenceNetworkFile=opts.ref, directed=not opts.undirected)
+        AUPRC, AUROC = evalSummarizer.computeAUC(
+                            userReferenceNetworkFile=opts.ref,
+                            directed=not opts.undirected,
+                            tfsFile=opts.tfs,
+                            ignoreEdgesFromTFs=opts.ignore_edges_from_tfs)
         AUPRC.to_csv(outDir+'AUPRC.csv')
         AUROC.to_csv(outDir+'AUROC.csv')
 

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -87,8 +87,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('--tfs', action="store", default=None,
       help="Path to a file containing list of transcription factors.\n")
 
-    parser.add_argument('--ignore-edges-from-tfs', action="store_true", default=False,
-      help="A flag to indicate whether to ignore edges from transcription factors or not. If ignore_edges_from_tfs=True, edges from transcription factors in the reference network will be ignored and considered a negative. This option requires the user to provide a list of transcription factors using the `--tfs` option.\n")
+    parser.add_argument('--only-edges-from-tfs', action="store_true", default=False,
+      help="A flag to indicate whether to ignore edges from non-transcription factors or not. If only_edges_from_tfs=True, edges from nodes other than transcription factors in the reference network will be ignored and considered a negative. This option requires the user to provide a list of transcription factors using the `--tfs` option.\n")
 
 
     return parser
@@ -127,7 +127,7 @@ def main():
                             userReferenceNetworkFile=opts.ref,
                             directed=not opts.undirected,
                             tfsFile=opts.tfs,
-                            ignoreEdgesFromTFs=opts.ignore_edges_from_tfs)
+                            onlyEdgesFromTFs=opts.only_edges_from_tfs)
         AUPRC.to_csv(outDir+'AUPRC.csv')
         AUROC.to_csv(outDir+'AUROC.csv')
 

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -125,7 +125,9 @@ def main():
     if (opts.clr):
         print('\n\nComputing inferred ranked edge list using CLR algorithm...')
 
-        evalSummarizer.computeCLR()
+        AUPRC, AUROC = evalSummarizer.computeCLR()
+        AUPRC.to_csv(outDir + 'CLR-AUPRC.csv')
+        AUROC.to_csv(outDir + 'CLR-AUROC.csv')
 
     # Compute median time taken
     if (opts.time):

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -18,7 +18,7 @@ from multiprocessing import Pool, cpu_count
 from networkx.convert_matrix import from_pandas_adjacency
 
 # local imports
-import BLEval as ev 
+import BLEval as ev
 
 def get_parser() -> argparse.ArgumentParser:
     '''
@@ -31,10 +31,10 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-c','--config', default='config.yaml',
         help="Configuration file containing list of datasets "
               "algorithms and output specifications.\n")
-    
+
     parser.add_argument('-a', '--auc', action="store_true", default=False,
         help="Compute median of areas under Precision-Recall and ROC curves.\n")
-    
+
     parser.add_argument('-j', '--jaccard', action="store_true", default=False,
       help="Compute median Jaccard index of predicted top-k networks "
       "for each algorithm for a given set of datasets generated "
@@ -44,7 +44,7 @@ def get_parser() -> argparse.ArgumentParser:
       help="Compute median Spearman Corr. of predicted edges "
       "for each algorithm  for a given set of datasets generated "
       " from the same ground truth network.\n")
-    
+
     parser.add_argument('-l', '--clr', action="store_true", default=False,
       help="Compute the infered ranked list using the CLR network algorithm"
       "for each algorithm for a given set of datasets generated "
@@ -52,15 +52,18 @@ def get_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('-t', '--time', action="store_true", default=False,
       help="Analyze time taken by each algorithm for a.\n")
-    
+
     parser.add_argument('-e', '--EPR', action="store_true", default=False,
       help="Compute median early precision.")
-    
+
     parser.add_argument('-s','--sEPR', action="store_true", default=False,
       help="Analyze median (signed) early precision for activation and inhibitory edges.")
 
     parser.add_argument('-m','--motifs', action="store_true", default=False,
       help="Compute network motifs in the predicted top-k networks.")
+
+    parser.add_argument('-b','--borda', action="store_true", default=False,
+      help="Compute edge ranked list using the borda method.")
 
 
     return parser
@@ -72,7 +75,7 @@ def parse_arguments():
     '''
     parser = get_parser()
     opts = parser.parse_args()
-    
+
     return opts
 
 def main():
@@ -83,59 +86,59 @@ def main():
 
     with open(config_file, 'r') as conf:
         evalConfig = ev.ConfigParser.parse(conf)
-        
+
     print('\nPost-run evaluation started...')
     evalSummarizer = ev.BLEval(evalConfig.input_settings, evalConfig.output_settings)
-    
+
     outDir = str(evalSummarizer.output_settings.base_dir) + \
             str(evalSummarizer.input_settings.datadir).split("inputs")[1] + "/"+\
             str(evalSummarizer.output_settings.output_prefix) + "-"
-    
-    # Compute and plot ROC, PRC and report median AUROC, AUPRC    
+
+    # Compute and plot ROC, PRC and report median AUROC, AUPRC
     if (opts.auc):
         print('\n\nComputing areas under ROC and PR curves...')
 
         AUPRC, AUROC = evalSummarizer.computeAUC()
         AUPRC.to_csv(outDir+'AUPRC.csv')
         AUROC.to_csv(outDir+'AUROC.csv')
-    
-    # Compute Jaccard index    
+
+    # Compute Jaccard index
     if (opts.jaccard):
         print('\n\nComputing Jaccard index...')
 
         jaccDict = evalSummarizer.computeJaccard()
         jaccDict.to_csv(outDir + "Jaccard.csv")
-        
+
     # Compute Spearman correlation scores
     if (opts.spearman):
         print('\n\nComputing Spearman\'s correlation...')
 
         corrDict = evalSummarizer.computeSpearman()
         corrDict.to_csv(outDir + "Spearman.csv")
-        
+
     # Compute inferred ranked edge list using CLR algorithm
     if (opts.clr):
         print('\n\nComputing inferred ranked edge list using CLR algorithm...')
 
         evalSummarizer.computeCLR()
-        
+
     # Compute median time taken
     if (opts.time):
         print('\n\nComputing time taken...')
 
         TimeDict = evalSummarizer.parseTime()
         pd.DataFrame(TimeDict).to_csv(outDir+'Times.csv')
-    
+
     # Compute early precision
     if (opts.EPR):
         print('\n\nComputing early precision values...')
         ePRDF = evalSummarizer.computeEarlyPrec()
         ePRDF.to_csv(outDir + "EPr.csv")
-                        
+
     # Compute early precision for activation and inhibitory edges
     if (opts.sEPR):
         print('\n\nComputing early precision values for activation and inhibitory edges...')
-        
+
         actDF, inhDF = evalSummarizer.computeSignedEPrec()
         actDF.to_csv(outDir + "EPr-Activation.csv")
         inhDF.to_csv(outDir + "EPr-Inhibitory.csv")
@@ -148,6 +151,12 @@ def main():
         FBL.to_csv(outDir+'NetworkMotifs-FBL.csv')
         FFL.to_csv(outDir+'NetworkMotifs-FFL.csv')
         MI.to_csv(outDir+'NetworkMotifs-MI.csv')
+
+    # Compute edge ranked list using the borda method
+    if (opts.borda):
+        print('\n\nComputing edge ranked list using the borda method')
+
+        evalSummarizer.computeBorda()
 
 
     print('\n\nEvaluation complete...\n')

--- a/BLEvalAggregator.py
+++ b/BLEvalAggregator.py
@@ -65,6 +65,11 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-b','--borda', action="store_true", default=False,
       help="Compute edge ranked list using the borda method.")
 
+    parser.add_argument('--borda-agg', action="store", default="average",
+      help="Method used to aggregate rank in borda method. Available options are {‘average’, ‘min’, ‘max’, ‘first’}, default ‘average’")
+
+    parser.add_argument('--borda-algo', action="append",
+      help="Algorithms used to compute rank in borda method. Default option runs Borda on all algorithm.")
 
     return parser
 
@@ -155,8 +160,7 @@ def main():
     # Compute edge ranked list using the borda method
     if (opts.borda):
         print('\n\nComputing edge ranked list using the borda method')
-
-        evalSummarizer.computeBorda()
+        evalSummarizer.computeBorda(selectedAlgorithms=opts.borda_algo, aggregationMethod=opts.borda_agg)
 
 
     print('\n\nEvaluation complete...\n')

--- a/config-files/Synthetic/dyn-LI.yaml
+++ b/config-files/Synthetic/dyn-LI.yaml
@@ -20,47 +20,47 @@ input_settings:
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_1"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_2"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_3"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_4"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_5"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_6"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_7"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_8"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_500_9"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
@@ -70,47 +70,47 @@ input_settings:
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_1"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_2"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_3"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_4"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_5"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_6"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_7"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_8"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_2000_9"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
@@ -120,47 +120,47 @@ input_settings:
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_1"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_2"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_3"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_4"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_5"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_6"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_7"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_8"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
           trueEdges: "refNetwork.csv"
-          
+
         - name: "dyn-LI_5000_9"
           exprData: "ExpressionData.csv"
           cellData: "PseudoTime.csv"
@@ -194,58 +194,58 @@ input_settings:
               nRep: [5]
 
         - name: "SCNS"
-          params: 
+          params:
               should_run: [True]
-              
-              
+
+
         - name: "SINCERITIES"
-          params: 
+          params:
               should_run: [True]
-                            
-              
+
+
         - name: "PIDC"
-          params: 
+          params:
               should_run: [True]
 
 
         - name: "GRNVBEM"
-          params: 
+          params:
               should_run: [True]
 
-              
+
 
         - name: "GENIE3"
-          params: 
+          params:
               should_run: [True]
-              
-              
-              
+
+
+
         - name: "GRNBOOST2"
-          params: 
+          params:
               should_run: [True]
-              
-              
-              
+
+
+
         - name: "LEAP"
-          params: 
+          params:
               should_run: [True]
               # Default maxLag value is 0.3
               # but it is very slow with 0.3
               # when we have more than 1000 cells.
               maxLag: [0.75]
 
-              
-                                         
+
+
         - name: "PPCOR"
-          params: 
+          params:
               should_run: [True]
               # Used in parsing output
               pVal: [0.01]
-              
-              
-              
+
+
+
         - name: "GRISLI"
-          params: 
+          params:
               should_run: [True]
               L: [10]
               R: [1000]
@@ -253,7 +253,7 @@ input_settings:
 
 
         - name: "SCINGE"
-          params: 
+          params:
               should_run: [True]
               lambda: [0.01]
               dT: [10]
@@ -266,14 +266,14 @@ input_settings:
 
 
         - name: "SCRIBE"
-          params: 
+          params:
               should_run: [True]
               ### required parameters
               # a list of delay values
               delay: ["0,1,5,10,25"]
               # any of 'RDI', 'uRDI', 'cRDI', or 'ucRDI'
               method: ['ucRDI']
-              # lower detection limit (expression below this 
+              # lower detection limit (expression below this
               # will be treated as zero.
               lowerDetectionLimit: [0]
               # expressionFamily: for synthetic data use uninormal

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scipy==1.1.0
 scikit_learn==0.21.2
 typing==3.6.6
 PyYAML==5.1.1
+rpy2


### PR DESCRIPTION
- Added option to  compute $k$-P-R curves defined as follows: a predicted edge $(a,b)$ is a TP if there is a path of length $\leq k$ between $a$ and $b$. So a $1$-P-R curve is just the regular P-R curve.
- Added option to specify reference network file as command line option. This option can be used to evaluate GRNs from real data on STRING interactions.
-  Added option to specify if the predictions and reference network should be treated as undirected. This option can be used to evaluate GRNs from real data on STRING interactions since STRING interactions are undirected in nature.