### PR TITLE
Fix for failed container build for SCODE

### DIFF
--- a/Algorithms/SCODE/Dockerfile
+++ b/Algorithms/SCODE/Dockerfile
@@ -6,7 +6,9 @@ USER root
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y gcc-8-base
+
+RUN apt-get install -y git
 
 RUN apt-get install -y ruby
 
@@ -23,3 +25,4 @@ RUN R -e "install.packages('https://cran.r-project.org/src/contrib/MASS_7.3-51.3
 
 
 RUN apt-get install time
+


### PR DESCRIPTION
apt-get install -y git was failing with the following error:

Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libc6-dev : Breaks: libgcc-8-dev (< 8.4.0-2~) but 8.3.0-3 is to be
installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be
caused by held packages.

This commit fixes the problem.